### PR TITLE
Copy-user-config

### DIFF
--- a/ex_installer/advanced_config.py
+++ b/ex_installer/advanced_config.py
@@ -42,8 +42,6 @@ class AdvancedConfig(WindowLayout):
 
         # Set up and configure the edit frame, which will contain the editboxes
         self.edit_frame = ctk.CTkFrame(self.main_frame, height=360)
-        self.edit_frame.grid_columnconfigure(0, weight=1)
-        self.edit_frame.grid_rowconfigure(2, weight=1)
         self.edit_frame.grid(column=0, row=0, sticky="nsew")
 
         self.edit_list = []  # remember list of files to edit
@@ -72,6 +70,10 @@ class AdvancedConfig(WindowLayout):
     def reload_view(self):
         """
         Build/Refresh items for this view, including the dynamic list of edit boxes
+
+        If two config files, display side by side which is quite practical
+
+        If more than two config files, use CTkTabview for a nicer editing experience
         """
         self.log.debug("in reload_view()")
 
@@ -98,10 +100,13 @@ class AdvancedConfig(WindowLayout):
         self.edit_textbox = {}
         edit_column = 0
         if (len(self.edit_list)) < 3:
+            self.edit_frame.grid_rowconfigure((0, 1), weight=0)
+            self.edit_frame.grid_rowconfigure(2, weight=1)
             for file_name in self.edit_list:
                 self.edit_frame.grid_columnconfigure(edit_column, weight=1)
                 self.log.debug("adding edit box for " + file_name)
-                self.edit_label[file_name] = ctk.CTkLabel(self.edit_frame, text=file_name)
+                self.edit_label[file_name] = ctk.CTkLabel(self.edit_frame, text=file_name,
+                                                          font=self.instruction_font)
                 self.edit_label[file_name].grid(column=edit_column, row=1, padx=5, pady=5, sticky="nsew")
                 self.edit_textbox[file_name] = ctk.CTkTextbox(self.edit_frame, border_width=2, wrap="none",
                                                               fg_color="#E5E5E5", activate_scrollbars=True)
@@ -111,13 +116,22 @@ class AdvancedConfig(WindowLayout):
                 self.edit_textbox[file_name].insert("0.0", text)
                 edit_column += 1
         else:
-            self.config_tabview = ctk.CTkTabview(self.edit_frame)
+            self.edit_frame.grid_columnconfigure(0, weight=1)
+            self.edit_frame.grid_rowconfigure(1, weight=1)
+            self.config_tabview = ctk.CTkTabview(self.edit_frame, border_width=2,
+                                                 segmented_button_fg_color="#00A3B9",
+                                                 segmented_button_unselected_color="#00A3B9",
+                                                 segmented_button_selected_color="#00353D",
+                                                 segmented_button_selected_hover_color="#017E8F",
+                                                 text_color="white")
             self.config_tabview.grid(column=0, row=1, padx=5, pady=5, sticky="nsew")
             for file_name in self.edit_list:
                 self.config_tabview.add(file_name)
-                self.edit_textbox[file_name] = ctk.CTkTextbox(self.config_tabview.tab(file_name), border_width=2, wrap="none",
-                                                              fg_color="#E5E5E5", activate_scrollbars=True)
-                self.edit_textbox[file_name].grid(column=0, row=0, padx=4, pady=5, sticky="nsew")
+                self.config_tabview.tab(file_name).grid_columnconfigure(0, weight=1)
+                self.config_tabview.tab(file_name).grid_rowconfigure(0, weight=1)
+                self.edit_textbox[file_name] = ctk.CTkTextbox(self.config_tabview.tab(file_name), border_width=2,
+                                                              wrap="none", fg_color="#E5E5E5", activate_scrollbars=True)
+                self.edit_textbox[file_name].grid(column=0, row=0, padx=5, pady=5, sticky="nsew")
                 file_path = fm.get_filepath(self.product_dir, file_name)
                 text = fm.read_config_file(file_path)
                 self.edit_textbox[file_name].insert("0.0", text)

--- a/ex_installer/advanced_config.py
+++ b/ex_installer/advanced_config.py
@@ -96,31 +96,31 @@ class AdvancedConfig(WindowLayout):
 
         self.edit_label = {}
         self.edit_textbox = {}
-        # edit_row = 1
-        # for file_name in self.edit_list:
-        #     self.log.debug("adding edit box for " + file_name)
-        #     self.edit_label[file_name] = ctk.CTkLabel(self.edit_frame, text=file_name)
-        #     self.edit_label[file_name].grid(column=0, row=edit_row, sticky="nsew")
-        #     self.edit_textbox[file_name] = ctk.CTkTextbox(self.edit_frame, border_width=2, border_spacing=5,
-        #                                                   fg_color="#E5E5E5", width=780, height=180)
-        #     self.edit_textbox[file_name].grid(column=1, row=edit_row, sticky="nsew")
-        #     file_path = fm.get_filepath(self.product_dir, file_name)
-        #     text = fm.read_config_file(file_path)
-        #     self.edit_textbox[file_name].insert("0.0", text)
-        #     edit_row += 1
         edit_column = 0
-        for file_name in self.edit_list:
-            self.edit_frame.grid_columnconfigure(edit_column, weight=1)
-            self.log.debug("adding edit box for " + file_name)
-            self.edit_label[file_name] = ctk.CTkLabel(self.edit_frame, text=file_name)
-            self.edit_label[file_name].grid(column=edit_column, row=1, padx=5, pady=5, sticky="nsew")
-            self.edit_textbox[file_name] = ctk.CTkTextbox(self.edit_frame, border_width=2, wrap="none",
-                                                          fg_color="#E5E5E5", activate_scrollbars=True)
-            self.edit_textbox[file_name].grid(column=edit_column, row=2, padx=4, pady=5, sticky="nsew")
-            file_path = fm.get_filepath(self.product_dir, file_name)
-            text = fm.read_config_file(file_path)
-            self.edit_textbox[file_name].insert("0.0", text)
-            edit_column += 1
+        if (len(self.edit_list)) < 3:
+            for file_name in self.edit_list:
+                self.edit_frame.grid_columnconfigure(edit_column, weight=1)
+                self.log.debug("adding edit box for " + file_name)
+                self.edit_label[file_name] = ctk.CTkLabel(self.edit_frame, text=file_name)
+                self.edit_label[file_name].grid(column=edit_column, row=1, padx=5, pady=5, sticky="nsew")
+                self.edit_textbox[file_name] = ctk.CTkTextbox(self.edit_frame, border_width=2, wrap="none",
+                                                              fg_color="#E5E5E5", activate_scrollbars=True)
+                self.edit_textbox[file_name].grid(column=edit_column, row=2, padx=4, pady=5, sticky="nsew")
+                file_path = fm.get_filepath(self.product_dir, file_name)
+                text = fm.read_config_file(file_path)
+                self.edit_textbox[file_name].insert("0.0", text)
+                edit_column += 1
+        else:
+            self.config_tabview = ctk.CTkTabview(self.edit_frame)
+            self.config_tabview.grid(column=0, row=1, padx=5, pady=5, sticky="nsew")
+            for file_name in self.edit_list:
+                self.config_tabview.add(file_name)
+                self.edit_textbox[file_name] = ctk.CTkTextbox(self.config_tabview.tab(file_name), border_width=2, wrap="none",
+                                                              fg_color="#E5E5E5", activate_scrollbars=True)
+                self.edit_textbox[file_name].grid(column=0, row=0, padx=4, pady=5, sticky="nsew")
+                file_path = fm.get_filepath(self.product_dir, file_name)
+                text = fm.read_config_file(file_path)
+                self.edit_textbox[file_name].insert("0.0", text)
 
         # Set next/back buttons
         if self.master.use_existing:  # return from whence you arrived

--- a/ex_installer/ex_commandstation.py
+++ b/ex_installer/ex_commandstation.py
@@ -104,8 +104,10 @@ class EXCommandStation(WindowLayout):
                     self.product_patch_version = patch
         if self.product_major_version >= 4 and self.product_minor_version >= 2:
             self.track_modes_switch.grid()
+            self.track_modes_frame.grid()
         else:
             self.track_modes_switch.grid_remove()
+            self.track_modes_frame.grid_remove()
 
     def setup_config_frame(self):
         """

--- a/ex_installer/select_device.py
+++ b/ex_installer/select_device.py
@@ -81,7 +81,7 @@ class SelectDevice(WindowLayout):
 
         # Create detected device label and grid
         grid_options = {"padx": 5, "pady": 5}
-        self.no_device_label = ctk.CTkLabel(self.select_device_frame, text="Click Scan for Devices to start",
+        self.no_device_label = ctk.CTkLabel(self.select_device_frame, text="Scanning for devices",
                                             font=self.bold_instruction_font)
         self.device_list_label = ctk.CTkLabel(self.device_list_frame, text="Select your device",
                                               font=self.instruction_font)
@@ -94,6 +94,7 @@ class SelectDevice(WindowLayout):
         self.list_device_button.grid(column=0, row=2)
 
         self.set_state()
+        self.list_devices("list_devices")
 
     def set_state(self):
         self.next_back.hide_log_button()

--- a/ex_installer/select_version_config.py
+++ b/ex_installer/select_version_config.py
@@ -81,7 +81,6 @@ class SelectVersionConfig(WindowLayout):
         self.product_dir = fm.get_install_dir(local_repo_dir)
         self.branch_name = pd[self.product]["default_branch"]
         self.setup_local_repo("setup_local_repo")
-        self.delete_config_files()
 
     def setup_version_frame(self):
         grid_options = {"padx": 5, "pady": 5}
@@ -145,7 +144,7 @@ class SelectVersionConfig(WindowLayout):
         self.version_frame.grid_rowconfigure((0, 1, 2), weight=1)
         self.version_label.grid(column=0, row=0, **grid_options)
         self.version_radio_frame.grid(column=0, row=1, **grid_options)
-        # self.config_radio_frame.grid(column=0, row=2, **grid_options)
+        self.config_radio_frame.grid(column=0, row=2, **grid_options)
 
     def setup_local_repo(self, event):
         """
@@ -156,13 +155,14 @@ class SelectVersionConfig(WindowLayout):
         - if so
             - if the product directory is already a cloned repo
             - any locally modified files that would interfere with Git commands
-            - any existing configuration files
+            - delete any existing configuration files
         - if not, clone repo
         - get list of versions, latest prod, and latest devel versions
         """
         if event == "setup_local_repo":
             self.log.debug("Setting up local repository")
             self.disable_input_states(self)
+            self.delete_config_files()
             if os.path.exists(self.product_dir) and os.path.isdir(self.product_dir):
                 if self.git.dir_is_git_repo(self.product_dir):
                     self.repo = self.git.get_repo(self.product_dir)

--- a/ex_installer/version.py
+++ b/ex_installer/version.py
@@ -7,28 +7,31 @@ This file is read by the application at runtime if run as a module, and is also
 read by the application build process to embed in the application details
 """
 
-ex_installer_version = "0.0.9"
+ex_installer_version = "0.0.10"
 
 """
 Version history:
 
-0.0.9 - Display serial device details for unknown/clone devices
-0.0.8 - Fix for DPI scaling bug when moving monitors (Harald Barth)
-0.0.7 - Add the ability to direct edit config files
-      - Add track manager configuration to EX-CommandStation config
-      - Disable selecting the WiFi channel in station mode for EX-CommandStation
-      - Update no device found message
-      - Enable/disable track manager configuration based on version
-0.0.6 - Add a serial monitor for viewing serial output and sending commands
-0.0.5 - Provide extra welcome information and instructions
-      - Rephrase from "upload" to "load" which is potentially less confusing and more appropriate language
-      - Refine Manage Arduino CLI text
-      - Fix bug where navigating from Load screen crashes application due to missing version parameter
-0.0.4 - Expose selected product version to product configuration view
-      - Add application and product versions to generated config file
-0.0.3 - Allow setting custom password for WiFi in AP mode
-0.0.2 - Separate repository and version management from EX-CommandStation configuration
-0.0.1 - Initial release:
-      - Configure, compile, upload EX-CommandStation
-      - Supports AVR, ESP32, and STM32
+0.0.10      - Automatically scan for devices on the Select Device view when starting
+            - Enable browsing for and using existing configuration files
+            - Add tabbed view for editing more than two configuration files
+0.0.9       - Display serial device details for unknown/clone devices
+0.0.8       - Fix for DPI scaling bug when moving monitors (Harald Barth)
+0.0.7       - Add the ability to direct edit config files
+            - Add track manager configuration to EX-CommandStation config
+            - Disable selecting the WiFi channel in station mode for EX-CommandStation
+            - Update no device found message
+            - Enable/disable track manager configuration based on version
+0.0.6       - Add a serial monitor for viewing serial output and sending commands
+0.0.5       - Provide extra welcome information and instructions
+            - Rephrase from "upload" to "load" which is potentially less confusing and more appropriate language
+            - Refine Manage Arduino CLI text
+            - Fix bug where navigating from Load screen crashes application due to missing version parameter
+0.0.4       - Expose selected product version to product configuration view
+            - Add application and product versions to generated config file
+0.0.3       - Allow setting custom password for WiFi in AP mode
+0.0.2       - Separate repository and version management from EX-CommandStation configuration
+0.0.1       - Initial release:
+            - Configure, compile, upload EX-CommandStation
+            - Supports AVR, ESP32, and STM32
 """


### PR DESCRIPTION
Enable using existing configuration files, using a tabbed view to edit if more than 2 files.

Enable scanning for devices automatically the first time the Select Device view is navigated to.