### PR TITLE
9-to-do-add-check-and-backup-option-for-config-files

### DIFF
--- a/ex_installer/ex_commandstation.py
+++ b/ex_installer/ex_commandstation.py
@@ -41,8 +41,8 @@ class EXCommandStation(WindowLayout):
 
     # List of supported displays and config lines for config.h
     supported_displays = {
-        "LCD - 16 columns x 2 rows": "#define LCD_DRIVER 0x27,16,2",
-        "LCD 16 columns x 4 rows": "#define LCD_DRIVER  0x27,16,4",
+        "LCD 16 columns x 2 rows": "#define LCD_DRIVER 0x27,16,2",
+        "LCD 16 columns x 4 rows": "#define LCD_DRIVER 0x27,16,4",
         "OLED 128 x 32": "#define OLED_DRIVER 128,32",
         "OLED 128 x 64": "#define OLED_DRIVER 128,64"
     }

--- a/ex_installer/file_manager.py
+++ b/ex_installer/file_manager.py
@@ -372,3 +372,15 @@ class FileManager:
             return failed_files
         else:
             return None
+
+    @staticmethod
+    def is_valid_dir(dir):
+        """
+        Simply checks directory exists and that it is a directory
+
+        Returns True or False
+        """
+        if os.path.exists(dir) and os.path.isdir(dir):
+            return True
+        else:
+            return False

--- a/ex_installer/serial_monitor.py
+++ b/ex_installer/serial_monitor.py
@@ -182,8 +182,10 @@ class SerialMonitor(ctk.CTkToplevel):
         """
         Function to update the textbox with output from the Arduino CLI in monitor mode
         """
+        self.output_textbox.configure(state="normal")
         self.output_textbox.insert("insert", output + "\n")
         self.output_textbox.see("end")
+        self.output_textbox.configure(state="disabled")
 
     def send_command(self, event=None):
         """

--- a/ex_installer/version.py
+++ b/ex_installer/version.py
@@ -17,6 +17,8 @@ Version history:
             - Add support for EX-Turntable
             - Improve error detection/handling for Arduino CLI commands
             - Fix bug where closing app with device monitor open waits for thread join and errors
+            - Set device manager output to read only
+            - Add option to backup generated config files to a selected folder
 0.0.13      - Add EX-IOExpander support
             - Add WiFi password validation in EX-CommandStation configuration
             - Add command history to device monitor


### PR DESCRIPTION
Fixed device monitor textbox so it is read only.

Added option to backup config files to selected folder.