### PR TITLE
Track-power-current-sense-host-name

### DIFF
--- a/ex_installer/compile_upload.py
+++ b/ex_installer/compile_upload.py
@@ -144,7 +144,7 @@ class CompileUpload(WindowLayout):
             self.next_back.set_back_command(lambda view=product: self.master.switch_view(view))
 
     def show_backup_button(self):
-        self.upload_button.configure(text="Upload again")
+        self.upload_button.configure(text="Load again")
         self.upload_button.grid_configure(columnspan=1)
         self.backup_config_button.grid()
 

--- a/ex_installer/ex_commandstation.py
+++ b/ex_installer/ex_commandstation.py
@@ -37,14 +37,16 @@ class EXCommandStation(WindowLayout):
     """
 
     hardware_text = ("Select the appropriate options on this page to suit the hardware devices you are using with " +
-                     "your EX-CommandStation device.\n\n")
+                     "your EX-CommandStation device.\n\n" +
+                     "If you are enabling WiFi or configuring TrackManager, enable the appropriate option and " +
+                     "navigate to the appropriate tab to configure the relevant options.")
 
     # List of supported displays and config lines for config.h
     supported_displays = {
-        "LCD 16 columns x 2 rows": "#define LCD_DRIVER 0x27,16,2",
-        "LCD 20 columns x 4 rows": "#define LCD_DRIVER 0x27,20,4",
-        "OLED 128 x 32": "#define OLED_DRIVER 128,32",
-        "OLED 128 x 64": "#define OLED_DRIVER 128,64"
+        "LCD 16 columns x 2 rows": "#define LCD_DRIVER 0x27,16,2\n",
+        "LCD 20 columns x 4 rows": "#define LCD_DRIVER 0x27,20,4\n",
+        "OLED 128 x 32": "#define OLED_DRIVER 128,32\n",
+        "OLED 128 x 64": "#define OLED_DRIVER 128,64\n"
     }
 
     # List of default config options to include in config.h
@@ -122,10 +124,10 @@ class EXCommandStation(WindowLayout):
                 if patch is not None:
                     self.product_patch_version = patch
         if self.product_major_version >= 4 and self.product_minor_version >= 2:
-            self.track_modes_switch.grid()
+            self.track_modes_switch.configure(state="normal")
         else:
             self.track_modes_switch.deselect()  # make sure it's off
-            self.track_modes_switch.grid_remove()
+            self.track_modes_switch.configure(state="disabled")
         self.set_track_modes()
 
     def setup_config_frame(self):
@@ -150,7 +152,8 @@ class EXCommandStation(WindowLayout):
                         "these unless you're comfortable you know what you're doing.")
         track_tip = ("To make use of the new TrackManager feature, you will need to enable this option and set the " +
                      "appropriate mode for each motor driver output. Click this tip to be redirected to our website " +
-                     "for further information.")
+                     "for further information. If this option is disabled, the version you have selected does not " +
+                     "include TrackManager features.")
         power_tip = ("To enable track power to be on during startup, enable this option. Note that it will also join " +
                      "the programming and main tracks.")
 
@@ -158,42 +161,81 @@ class EXCommandStation(WindowLayout):
         self.hardware_label = ctk.CTkLabel(self.config_frame, text=self.hardware_text,
                                            wraplength=780, font=self.instruction_font)
 
+        # Setup tabview for config options
+        self.config_tabview = ctk.CTkTabview(self.config_frame, border_width=2,
+                                             segmented_button_fg_color="#00A3B9",
+                                             segmented_button_unselected_color="#00A3B9",
+                                             segmented_button_selected_color="#00353D",
+                                             segmented_button_selected_hover_color="#017E8F",
+                                             text_color="white")
+        tab_list = [
+            "General",
+            "WiFi Options",
+            "TrackManager Config"
+        ]
+        for tab in tab_list:
+            self.config_tabview.add(tab)
+            self.config_tabview.tab(tab).grid_columnconfigure(0, weight=1)
+            self.config_tabview.tab(tab).grid_rowconfigure(0, weight=1)
+
+        # Tab frames
+        tab_frame_options = {"column": 0, "row": 0, "sticky": "nsew"}
+        self.general_tab_frame = ctk.CTkFrame(self.config_tabview.tab("General"), border_width=0)
+        self.general_tab_frame.grid(**tab_frame_options)
+        self.wifi_tab_frame = ctk.CTkFrame(self.config_tabview.tab("WiFi Options"), border_width=0)
+        self.wifi_tab_frame.grid(**tab_frame_options)
+        self.track_tab_frame = ctk.CTkFrame(self.config_tabview.tab("TrackManager Config"), border_width=0)
+        self.track_tab_frame.grid(**tab_frame_options)
+
+        # Create options frames
+        self.switch_frame = ctk.CTkFrame(self.general_tab_frame, border_width=0)
+        self.options_frame = ctk.CTkFrame(self.general_tab_frame, border_width=0)
+
         # Set up motor driver widgets
-        self.motor_driver_label = ctk.CTkLabel(self.config_frame, text="Select your motor driver")
-        self.motor_driver_combo = ctk.CTkComboBox(self.config_frame, values=["Select motor driver"],
+        self.motor_driver_label = ctk.CTkLabel(self.options_frame, text="Select your motor driver",
+                                               font=self.instruction_font)
+        self.motor_driver_combo = ctk.CTkComboBox(self.options_frame, values=["Select motor driver"],
                                                   width=300, command=self.check_motor_driver)
         CreateToolTip(self.motor_driver_combo, motor_tip,
                       "https://dcc-ex.com/reference/hardware/motor-boards.html")
 
         # Set up display widgets
+        self.display_type_label = ctk.CTkLabel(self.options_frame, text="Select display type (if in use):",
+                                               font=self.instruction_font)
         self.display_enabled = ctk.StringVar(self, value="off")
-        self.display_switch = ctk.CTkSwitch(self.config_frame, text="I have a display", width=150,
+        self.display_type = ctk.StringVar(self)
+        self.display_switch = ctk.CTkSwitch(self.switch_frame, text="I have a display", width=200,
                                             onvalue="on", offvalue="off", variable=self.display_enabled,
-                                            command=self.set_display)
+                                            command=self.set_display, font=self.instruction_font)
         CreateToolTip(self.display_switch, display_tip,
                       "https://dcc-ex.com/reference/hardware/i2c-displays.html")
-        self.display_combo = ctk.CTkComboBox(self.config_frame, values=list(self.supported_displays),
-                                             width=300)
+        self.display_radio_frame = ctk.CTkFrame(self.options_frame, fg_color="#D9D9D9", border_width=0)
+        row = 0
+        for display in self.supported_displays.keys():
+            display_radio = ctk.CTkRadioButton(self.display_radio_frame, text=display, variable=self.display_type,
+                                               font=self.instruction_font, value=self.supported_displays[display],
+                                               width=200)
+            display_radio.grid(column=0, row=row, sticky="w", **grid_options)
+            if row == 0:
+                display_radio.select()
+            row += 1
 
         # Set up WiFi widgets
         self.wifi_type = ctk.IntVar(self, value=0)
         self.wifi_channel = ctk.StringVar(self, value=1)
         self.wifi_enabled = ctk.StringVar(self, value="off")
-        self.wifi_frame = ctk.CTkFrame(self.config_frame, border_width=0)
-        self.wifi_switch = ctk.CTkSwitch(self.config_frame, text="I have WiFi", width=150,
+        self.wifi_switch = ctk.CTkSwitch(self.switch_frame, text="I have WiFi", width=200,
                                          onvalue="on", offvalue="off", variable=self.wifi_enabled,
-                                         command=self.set_wifi)
+                                         command=self.set_wifi, font=self.instruction_font)
         CreateToolTip(self.wifi_switch, wifi_tip,
                       "https://dcc-ex.com/ex-commandstation/advanced-setup/supported-wifi/index.html")
-        self.wifi_options_frame = ctk.CTkFrame(self.wifi_frame,
-                                               border_width=2,
-                                               fg_color="#E5E5E5")
-        self.wifi_ap_radio = ctk.CTkRadioButton(self.wifi_options_frame,
+        self.wifi_options_frame = ctk.CTkFrame(self.wifi_tab_frame, border_width=0)
+        self.wifi_ap_radio = ctk.CTkRadioButton(self.wifi_options_frame, width=400,
                                                 text="Use my EX-CommandStation as an access point",
                                                 variable=self.wifi_type,
                                                 command=self.set_wifi_widgets,
                                                 value=0)
-        self.wifi_st_radio = ctk.CTkRadioButton(self.wifi_options_frame,
+        self.wifi_st_radio = ctk.CTkRadioButton(self.wifi_options_frame, width=400,
                                                 text="Connect my EX-CommandStation to my existing wireless network",
                                                 variable=self.wifi_type,
                                                 command=self.set_wifi_widgets,
@@ -217,20 +259,20 @@ class EXCommandStation(WindowLayout):
 
         # Ethernet switch
         self.ethernet_enabled = ctk.StringVar(self, value="off")
-        self.ethernet_switch = ctk.CTkSwitch(self.config_frame, text="I have ethernet", width=150,
+        self.ethernet_switch = ctk.CTkSwitch(self.switch_frame, text="I have ethernet", width=200,
                                              onvalue="on", offvalue="off", variable=self.ethernet_enabled,
-                                             command=self.set_ethernet)
+                                             command=self.set_ethernet, font=self.instruction_font)
         CreateToolTip(self.ethernet_switch, ethernet_tip,
                       "https://dcc-ex.com/reference/hardware/ethernet-boards.html")
 
         # Track Manager Options
         self.track_modes_enabled = ctk.StringVar(self, value="off")
-        self.track_modes_switch = ctk.CTkSwitch(self.config_frame, text="Set track modes", width=150,
+        self.track_modes_switch = ctk.CTkSwitch(self.switch_frame, text="Configure TrackManager", width=200,
                                                 onvalue="on", offvalue="off", variable=self.track_modes_enabled,
-                                                command=self.set_track_modes)
+                                                command=self.set_track_modes, font=self.instruction_font)
         CreateToolTip(self.track_modes_switch, track_tip,
                       "https://dcc-ex.com/under-development/track-manager.html")
-        self.track_modes_frame = ctk.CTkFrame(self.config_frame, border_width=2, fg_color="#E5E5E5")
+        self.track_modes_frame = ctk.CTkFrame(self.track_tab_frame, border_width=0)
         self.track_a_label = ctk.CTkLabel(self.track_modes_frame, text="Track A:")
         self.track_a_combo = ctk.CTkComboBox(self.track_modes_frame, values=list(self.trackmanager_modes),
                                              width=100)
@@ -241,31 +283,27 @@ class EXCommandStation(WindowLayout):
         self.track_b_combo.set("PROG")
 
         # Set track power on startup
-        self.power_on_switch = ctk.CTkSwitch(self.config_frame, text="Power on", width=150,
-                                             onvalue="on", offvalue="off")
+        self.power_on_switch = ctk.CTkSwitch(self.switch_frame, text="Start with power on", width=200,
+                                             onvalue="on", offvalue="off", font=self.instruction_font)
         CreateToolTip(self.power_on_switch, power_tip)
-        self.power_on_label = ctk.CTkLabel(self.config_frame, font=self.instruction_font,
-                                           text="Turn track power on at startup and join program/main")
 
         # Advanced configuration option
         self.advanced_config_enabled = ctk.StringVar(self, value="off")
-        self.advanced_config_switch = ctk.CTkSwitch(self.config_frame, text="Advanced Config", width=150,
+        self.advanced_config_switch = ctk.CTkSwitch(self.switch_frame, text="Advanced Config", width=200,
                                                     onvalue="on", offvalue="off", variable=self.advanced_config_enabled,
-                                                    command=self.set_advanced_config)
+                                                    command=self.set_advanced_config, font=self.instruction_font)
         CreateToolTip(self.advanced_config_switch, advanced_tip)
-        self.advanced_config_label = ctk.CTkLabel(self.config_frame,
-                                                  text="Config files can be directly edited on next screen")
 
         # Layout wifi_frame
-        self.wifi_frame.grid_columnconfigure((0, 1), weight=1)
-        self.wifi_frame.grid_rowconfigure(0, weight=1)
+        self.wifi_tab_frame.grid_columnconfigure((0, 1), weight=1)
+        self.wifi_tab_frame.grid_rowconfigure(0, weight=1)
         self.wifi_options_frame.grid_columnconfigure((0, 1, 2, 3), weight=1)
         self.wifi_options_frame.grid_rowconfigure((0, 1, 2, 3), weight=1)
         self.wifi_channel_frame.grid_columnconfigure(0, weight=1)
         self.wifi_channel_frame.grid_rowconfigure((0, 1, 2, 3), weight=1)
         self.wifi_options_frame.grid(column=1, row=0)
-        self.wifi_ap_radio.grid(column=0, row=0, columnspan=4, sticky="w", **grid_options)
-        self.wifi_st_radio.grid(column=0, row=1, columnspan=4, sticky="w", **grid_options)
+        self.wifi_ap_radio.grid(column=0, row=0, columnspan=4, **grid_options)
+        self.wifi_st_radio.grid(column=0, row=1, columnspan=4, **grid_options)
         self.wifi_ssid_label.grid(column=0, row=2, **grid_options)
         self.wifi_ssid_entry.grid(column=1, row=2, **grid_options)
         self.wifi_pwd_label.grid(column=2, row=2, **grid_options)
@@ -276,37 +314,62 @@ class EXCommandStation(WindowLayout):
         self.wifi_channel_entry.grid(column=2, row=0)
         self.wifi_channel_plus.grid(column=3, row=0, sticky="w", padx=(0, 5))
 
-        # layout track_frame
-        self.track_a_label.grid(column=0, row=0, stick="e", **grid_options)
+        # Layout switch frame
+        self.display_switch.grid(column=0, row=0, **grid_options)
+        self.wifi_switch.grid(column=0, row=1, **grid_options)
+        self.ethernet_switch.grid(column=0, row=2, **grid_options)
+        self.track_modes_switch.grid(column=0, row=3, **grid_options)
+        self.power_on_switch.grid(column=0, row=4, **grid_options)
+        self.advanced_config_switch.grid(column=0, row=5, sticky="s", **grid_options)
+
+        # Layout options frame
+        self.options_frame.grid_columnconfigure((0, 1), weight=1)
+        self.options_frame.grid_rowconfigure((0, 1, 2), weight=1)
+        self.motor_driver_label.grid(column=0, row=0, sticky="e", **grid_options)
+        self.motor_driver_combo.grid(column=1, row=0, sticky="w", **grid_options)
+        self.display_type_label.grid(column=0, row=1, columnspan=2, sticky="w", padx=5, pady=(5, 1))
+        self.display_radio_frame.grid(column=0, row=2, columnspan=2, sticky="w", padx=5, pady=(1, 5))
+
+        # Layout track_frame
+        self.track_tab_frame.grid_columnconfigure(0, weight=1)
+        self.track_tab_frame.grid_rowconfigure(0, weight=1)
+        self.track_modes_frame.grid_columnconfigure((0, 1), weight=1)
+        self.track_modes_frame.grid_rowconfigure((0, 1), weight=1)
+        self.track_a_label.grid(column=0, row=0, sticky="e", **grid_options)
         self.track_a_combo.grid(column=1, row=0, sticky="w", **grid_options)
-        self.track_b_label.grid(column=0, row=1, stick="e", **grid_options)
+        self.track_b_label.grid(column=0, row=1, sticky="e", **grid_options)
         self.track_b_combo.grid(column=1, row=1, sticky="w", **grid_options)
 
+        # Layout general tab
+        self.general_tab_frame.grid_columnconfigure(0, weight=1)
+        self.general_tab_frame.grid_columnconfigure(1, weight=2)
+        self.general_tab_frame.grid_rowconfigure(0, weight=1)
+        self.switch_frame.grid(column=0, row=0, **grid_options)
+        self.options_frame.grid(column=1, row=0, **grid_options)
+
+        # Layout WiFi tab
+        self.wifi_options_frame.grid(column=0, row=0, sticky="nsew")
+
+        # Layout TrackManager tab
+        self.track_modes_frame.grid(column=0, row=0, sticky="nsew")
+
         # Layout config_frame
-        self.hardware_label.grid(column=0, row=2, columnspan=2, **grid_options)
-        self.motor_driver_label.grid(column=0, row=3, stick="e", **grid_options)
-        self.motor_driver_combo.grid(column=1, row=3, sticky="w", **grid_options)
-        self.display_switch.grid(column=0, row=4, sticky="e", **grid_options)
-        self.display_combo.grid(column=1, row=4, sticky="w", **grid_options)
-        self.wifi_switch.grid(column=0, row=5, sticky="e", **grid_options)
-        self.wifi_frame.grid(column=1, row=5, sticky="w", **grid_options)
-        self.ethernet_switch.grid(column=0, row=6, sticky="e", **grid_options)
-        self.track_modes_switch.grid(column=0, row=7, sticky="e", **grid_options)
-        self.track_modes_frame.grid(column=1, row=7, sticky="w", **grid_options)
-        self.power_on_switch.grid(column=0, row=8, sticky="e", **grid_options)
-        self.power_on_label.grid(column=1, row=8, stick="w", **grid_options)
-        self.advanced_config_switch.grid(column=0, row=9, sticky="e", **grid_options)
-        self.advanced_config_label.grid(column=1, row=9, sticky="w", **grid_options)
+        self.config_frame.grid_columnconfigure(0, weight=1)
+        self.config_frame.grid_rowconfigure(1, weight=1)
+        self.hardware_label.grid(column=0, row=0, **grid_options)
+        self.config_tabview.grid(column=0, row=1, sticky="nsew", **grid_options)
 
     def set_display(self):
         """
         Sets display options on or off
         """
         if self.display_switch.get() == "on":
-            self.display_combo.grid()
+            for widget in self.display_radio_frame.winfo_children():
+                widget.configure(state="normal")
             self.log.debug("Display enabled")
         else:
-            self.display_combo.grid_remove()
+            for widget in self.display_radio_frame.winfo_children():
+                widget.configure(state="disabled")
             self.log.debug("Display disabled")
 
     def set_track_modes(self):
@@ -314,10 +377,10 @@ class EXCommandStation(WindowLayout):
         Sets track mode options on or off
         """
         if self.track_modes_switch.get() == "on":
-            self.track_modes_frame.grid()
+            self.config_tabview._segmented_button._buttons_dict["TrackManager Config"].configure(state="normal")
             self.log.debug("Track modes frame shown")
         else:
-            self.track_modes_frame.grid_remove()
+            self.config_tabview._segmented_button._buttons_dict["TrackManager Config"].configure(state="disabled")
             self.log.debug("Track modes frame hidden")
 
     def set_advanced_config(self):
@@ -326,12 +389,10 @@ class EXCommandStation(WindowLayout):
         """
         if self.advanced_config_switch.get() == "on":
             self.master.advanced_config = True
-            self.advanced_config_label.grid()
             self.next_back.set_next_text("Advanced Config")
             self.log.debug("Manual Edit enabled")
         else:
             self.master.advanced_config = False
-            self.advanced_config_label.grid_remove()
             self.next_back.set_next_text("Compile and load")
             self.log.debug("Manual Edit disabled")
 
@@ -342,11 +403,11 @@ class EXCommandStation(WindowLayout):
         if self.wifi_switch.get() == "on":
             if self.ethernet_switch.get() == "on":
                 self.ethernet_switch.deselect()
-            self.wifi_frame.grid()
+            self.config_tabview._segmented_button._buttons_dict["WiFi Options"].configure(state="normal")
             self.set_wifi_widgets()
             self.log.debug("WiFi enabled")
         else:
-            self.wifi_frame.grid_remove()
+            self.config_tabview._segmented_button._buttons_dict["WiFi Options"].configure(state="disabled")
             self.log.debug("WiFi disabled")
 
     def set_wifi_widgets(self):
@@ -484,11 +545,7 @@ class EXCommandStation(WindowLayout):
             line = "#define MOTOR_SHIELD_TYPE " + self.motor_driver_combo.get() + "\n"
             config_list.append(line)
         if self.display_switch.get() == "on":
-            if not self.display_combo.get():
-                param_errors.append("Display type not selected")
-            else:
-                line = self.supported_displays[self.display_combo.get()] + "\n"
-                config_list.append(line)
+            config_list.append(self.display_type.get())
         if self.wifi_switch.get() == "on":
             if self.wifi_type.get() == 0:
                 config_list.append('#define WIFI_SSID "Your network name"\n')

--- a/ex_installer/product_details.py
+++ b/ex_installer/product_details.py
@@ -41,7 +41,7 @@ product_details = {
             "config.h"
         ],
         "other_config_files": [
-            r"(^myHal\.cpp$)",
+            r"^my.*\.[^?]*example\.cpp$|(^my.*\.cpp$)",
             r"^my.*\.[^?]*example\.h$|(^my.*\.h$)"
         ]
     },

--- a/ex_installer/serial_monitor.py
+++ b/ex_installer/serial_monitor.py
@@ -41,17 +41,17 @@ monitor_highlights = {
     "WiFi AP IP": {
         "regex": r"^\<\*\sWifi\sAP\sIP\s(\d*\.\d*\.\d*\.\d*)\s\*\>$",
         "matches": 1,
-        "tag": "orange"
+        "tag": "purple"
     },
     "Port (ESP32)": {
         "regex": r"^\<\*\sServer\swill\sbe\sstarted\son\sport\s(\d*)\s\*\>$",
         "matches": 1,
-        "tag": "oragne"
+        "tag": "purple"
     },
     "Port (ESP8266)": {
         "regex": r"^AT\+CIPSERVER=\d*,(\d*).*$",
         "matches": 1,
-        "tag": "orange"
+        "tag": "purple"
     },
     "WiFi Firmware": {
         "regex": r"^AT\sversion\:(.+?)$",
@@ -66,7 +66,7 @@ monitor_highlights = {
     "WiFi ST IP": {
         "regex": r"\"(\d*\.\d*\.\d*\.\d*)\"",
         "matches": 1,
-        "tag": "orange"
+        "tag": "purple"
     }
 }
 
@@ -172,11 +172,15 @@ class SerialMonitor(ctk.CTkToplevel):
         self.output_textbox.tag_config("blue",
                                        background="blue",
                                        foreground="white")
-        self.output_textbox.tag_add("orange", "end")
-        self.output_textbox.tag_config("orange",
-                                       background="orange",
+        self.output_textbox.tag_add("purple", "end")
+        self.output_textbox.tag_config("purple",
+                                       background="purple3",
                                        foreground="white")
-        self.output_textbox.tag_add("red", "end")
+        self.output_textbox.tag_add("warning", "end")
+        self.output_textbox.tag_config("warning",
+                                       background="orange red",
+                                       foreground="white")
+        self.output_textbox.tag_add("error", "end")
         self.output_textbox.tag_config("red",
                                        background="red",
                                        foreground="white")

--- a/ex_installer/version.py
+++ b/ex_installer/version.py
@@ -22,6 +22,11 @@ Version history:
             - Add highlights to device monitor for version and WiFi info
             - Updated 4 row LCD definition for 20 columns
             - Add option to power on/join at startup
+            - Revised EX-CommandStation configuration layout
+            - Updated optional config file list for EX-CommandStation to include my*.cpp
+            - Enable overriding current limit as introduced in 4.2.61
+            - Enable setting WiFi hostname in ST mode
+            - Enable setting loco/cab IDs in DC/DCX mode for TrackManager
 0.0.13      - Add EX-IOExpander support
             - Add WiFi password validation in EX-CommandStation configuration
             - Add command history to device monitor

--- a/ex_installer/version.py
+++ b/ex_installer/version.py
@@ -21,6 +21,7 @@ Version history:
             - Add option to backup generated config files to a selected folder
             - Add highlights to device monitor for version and WiFi info
             - Updated 4 row LCD definition for 20 columns
+            - Add option to power on/join at startup
 0.0.13      - Add EX-IOExpander support
             - Add WiFi password validation in EX-CommandStation configuration
             - Add command history to device monitor


### PR DESCRIPTION
Updated 4 row LCD definition for 20 columns
Add option to power on/join at startup
Revised EX-CommandStation configuration layout
Updated optional config file list for EX-CommandStation to include my*.cpp
Enable overriding current limit as introduced in 4.2.61
Enable setting WiFi hostname in ST mode
Enable setting loco/cab IDs in DC/DCX mode for TrackManager