### PR TITLE
Disable-platform-sliders

### DIFF
--- a/ex_installer/manage_arduino_cli.py
+++ b/ex_installer/manage_arduino_cli.py
@@ -35,6 +35,7 @@ class ManageArduinoCLI(WindowLayout):
     intro_text = ("We use the Arduino Command Line Interface (CLI) to upload the DCC-EX products to your Arduino. " +
                   "The CLI eliminates the need to install the more daunting Arduino IDE. EX-Installer is able to " +
                   "manage the installation and updating of the Arduino CLI for you at the click of a button.")
+    csb1_text = ("Important! If using the EX-CSB1, you must enable support for Espressif ESP32 below.")
     installed_text = "The Arduino CLI is installed"
     not_installed_text = "The Arduino CLI is not installed"
     install_instruction_text = ("To install the Arduino CLI, simply click the install button.\n\n" +
@@ -149,8 +150,9 @@ class ManageArduinoCLI(WindowLayout):
         self.manage_cli_frame = ctk.CTkFrame(self.main_frame, height=360)
         self.manage_cli_frame.grid(column=0, row=0, sticky="nsew", ipadx=5, ipady=5)
         self.manage_cli_frame.grid_columnconfigure((0, 1), weight=1)
-        self.manage_cli_frame.grid_rowconfigure((0, 2), weight=4)
-        self.manage_cli_frame.grid_rowconfigure(1, weight=1)
+        self.manage_cli_frame.grid_rowconfigure((0, 1), weight=2)
+        self.manage_cli_frame.grid_rowconfigure(2, weight=1)
+        self.manage_cli_frame.grid_rowconfigure(3, weight=4)
 
         # Create state and instruction labels and manage CLI button
         label_options = {"wraplength": 700}
@@ -158,6 +160,10 @@ class ManageArduinoCLI(WindowLayout):
                                         text=self.intro_text,
                                         font=self.instruction_font,
                                         **label_options)
+        self.csb1_label = ctk.CTkLabel(self.manage_cli_frame,
+                                       text=self.csb1_text,
+                                       font=self.bold_instruction_font,
+                                       **label_options)
         self.cli_state_label = ctk.CTkLabel(self.manage_cli_frame,
                                             font=self.instruction_font,
                                             **label_options)
@@ -201,10 +207,11 @@ class ManageArduinoCLI(WindowLayout):
 
         # Layout frame
         self.intro_label.grid(column=0, row=0, columnspan=2)
-        self.cli_state_label.grid(column=0, row=1)
-        self.manage_cli_button.grid(column=1, row=1)
-        self.instruction_label.grid(column=0, row=2)
-        self.extra_platforms_frame.grid(column=1, row=2, ipadx=5, ipady=5)
+        self.csb1_label.grid(column=0, row=1, columnspan=2)
+        self.cli_state_label.grid(column=0, row=2)
+        self.manage_cli_button.grid(column=1, row=2)
+        self.instruction_label.grid(column=0, row=3)
+        self.extra_platforms_frame.grid(column=1, row=3, ipadx=5, ipady=5)
 
         self.set_state()
 
@@ -216,6 +223,9 @@ class ManageArduinoCLI(WindowLayout):
                                            font=self.instruction_font)
             self.instruction_label.configure(text=self.refresh_instruction_text)
             self.manage_cli_button.configure(text="Refresh Arduino CLI", command=self._generate_refresh_cli)
+            for child in self.extra_platforms_frame.winfo_children():
+                if isinstance(child, ctk.CTkSwitch):
+                    child.configure(state="normal")
             self._generate_check_cli()
         else:
             self.cli_state_label.configure(text=self.not_installed_text,
@@ -223,6 +233,9 @@ class ManageArduinoCLI(WindowLayout):
                                            font=self.bold_instruction_font)
             self.instruction_label.configure(text=self.install_instruction_text)
             self.manage_cli_button.configure(text="Install Arduino CLI", command=self._generate_install_cli)
+            for child in self.extra_platforms_frame.winfo_children():
+                if isinstance(child, ctk.CTkSwitch):
+                    child.configure(state="disabled")
             self.next_back.disable_next()
 
     def update_package_list(self, switch):

--- a/ex_installer/version.py
+++ b/ex_installer/version.py
@@ -15,6 +15,8 @@ Version history:
 0.0.21      - Adding STM32 Ethernet support, and support for more platform targets
             - STM32 upload now via serial SWD (swdMethod) instead of DFU USB memory stick emulation
             - Windows EX-Installer now distributed as a setup file using Inno Setup
+            - Don't allow extra plaftorms to be installed until the CLI is installed
+            - Add note for EX-CSB1 users to enable ESP32 support
 0.0.20      - Fix bug with Windows file system path preventing cloning repositories
 0.0.19      - NOTE: Support for Windows 32bit is deprecated in this release
             - Building STM32 platforms on Windows 32bit is no longer possible


### PR DESCRIPTION
Disable platform sliders until CLI is installed.

Add extra bold note for CSB1 users to enable ESP32 support.