### PR TITLE
Add actionable Python and pyserial preflight checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,16 @@ In this instance, it is recommended to run in a virtual environment. Assuming Py
 
 - Clone the repository with `git clone https://github.com/DCC-EX/EX-Installer.git`
 - Change into the newly created directory
-- Create a virtual environment with `virtualenv venv`
+- Create a virtual environment with `python -m venv venv` (Python 3.10 or newer)
 - Activate the virtual environment:
   - Windows: `venv\scripts\activate`
   - Linux/macOS: `source venv/bin/activate`
 - Install required modules with `pip install -r requirements.txt`
 - Run as a module with `python -m ex_installer`
+
+EX-Installer checks the Python version and the `pyserial` upload dependency before
+starting the GUI. If either is unavailable, the command prints the exact corrective
+command and exits without opening the application.
 
 ## Versioning
 

--- a/ex_installer/__main__.py
+++ b/ex_installer/__main__.py
@@ -29,13 +29,24 @@ import os
 import argparse
 import sys
 
-# Import local modules
-from ex_installer.ex_installer import EXInstaller
-from ex_installer.file_manager import FileManager as fm
+from ex_installer.preflight import check_environment, format_errors
+
+
+def run_preflight():
+    """Check interpreter and upload dependencies before loading the GUI."""
+    errors = check_environment()
+    if errors:
+        print(format_errors(errors), file=sys.stderr)
+        return False
+    return True
 
 
 def main(debug, fake):
     """
+    # Import GUI modules only after preflight so missing dependencies are actionable.
+    from ex_installer.ex_installer import EXInstaller
+    from ex_installer.file_manager import FileManager as fm
+
     Main method to start the application.
 
     Arguments:
@@ -103,6 +114,9 @@ def main(debug, fake):
 
 
 if __name__ == "__main__":
+    if not run_preflight():
+        sys.exit(1)
+
     # Setup command line parser with debug argument
     parser = argparse.ArgumentParser()
     parser.add_argument("-D", "--debug", action="store_true", help="Set debug log level")

--- a/ex_installer/preflight.py
+++ b/ex_installer/preflight.py
@@ -1,0 +1,50 @@
+"""Checks that can run before importing the GUI and its third-party modules."""
+
+import importlib.util
+import sys
+
+
+MIN_PYTHON = (3, 10)
+REQUIRED_MODULES = {
+    "serial": "pyserial (install with: python -m pip install -r requirements.txt)",
+}
+
+
+def check_python_version(version=None):
+    """Return an actionable error for unsupported Python versions, or ``None``."""
+    version = version or sys.version_info
+    if version[:2] < MIN_PYTHON:
+        return (
+            f"EX-Installer requires Python {MIN_PYTHON[0]}.{MIN_PYTHON[1]} or newer; "
+            f"Python {version[0]}.{version[1]} is installed. "
+            "Install a supported Python version and recreate the virtual environment."
+        )
+    return None
+
+
+def check_dependencies(module_finder=importlib.util.find_spec):
+    """Return actionable errors for dependencies needed during device upload."""
+    errors = []
+    for module, install_hint in REQUIRED_MODULES.items():
+        try:
+            available = module_finder(module) is not None
+        except (ImportError, ModuleNotFoundError, ValueError):
+            available = False
+        if not available:
+            errors.append(f"Missing dependency '{module}': {install_hint}")
+    return errors
+
+
+def check_environment(version=None, module_finder=importlib.util.find_spec):
+    """Return all preflight errors without importing the GUI."""
+    errors = []
+    python_error = check_python_version(version)
+    if python_error:
+        errors.append(python_error)
+    errors.extend(check_dependencies(module_finder))
+    return errors
+
+
+def format_errors(errors):
+    """Format preflight failures for a terminal or launcher error dialog."""
+    return "EX-Installer cannot start:\n\n" + "\n".join(f"- {error}" for error in errors)

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,29 @@
+import unittest
+
+from ex_installer.preflight import check_dependencies, check_environment, check_python_version, format_errors
+
+
+class PreflightTests(unittest.TestCase):
+    def test_accepts_supported_python(self):
+        self.assertIsNone(check_python_version((3, 10)))
+        self.assertIsNone(check_python_version((3, 13)))
+
+    def test_rejects_old_python_with_recovery_hint(self):
+        error = check_python_version((3, 9))
+        self.assertIn("Python 3.10 or newer", error)
+        self.assertIn("recreate the virtual environment", error)
+
+    def test_reports_missing_pyserial(self):
+        errors = check_dependencies(lambda name: None)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("pyserial", errors[0])
+        self.assertIn("python -m pip install -r requirements.txt", errors[0])
+
+    def test_combines_python_and_dependency_errors(self):
+        errors = check_environment((3, 9), lambda name: None)
+        self.assertEqual(len(errors), 2)
+        self.assertTrue(format_errors(errors).startswith("EX-Installer cannot start:"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope  This PR is a bounded preflight improvement for the Python-run EX-Installer path:  - Check for Python 3.10 or newer before importing GUI dependencies. - Check that the serial module supplied by pyserial is importable before startup, and print the exact recovery command when it is missing. - Document venv setup and the supported Python minimum. - Add isolated regression tests for supported/unsupported Python versions, missing pyserial, combined failures, and formatted output.  Explicitly out of scope:  - A broad dependency-pin rewrite or an unverified claim that every Python 3.13/3.14 package combination installs successfully. - Rebuilding or replacing packaged binaries. - Changes to upload protocols, product configuration, firmware, hardware behavior, or unrelated application modules. - Physical hardware validation or treating the fork as approval to merge.  ## Issue and PR context  - [Issue #208](https://github.com/DCC-EX/EX-Installer/issues/208) reports a missing serial module during Linux ESP32 upload; the source requirements already list pyserial, so this makes the missing runtime dependency actionable before the GUI loads. - [Issue #216](https://github.com/DCC-EX/EX-Installer/issues/216) reports installation problems with Python 3.13.5; this PR enforces and documents the existing Python 3.10 minimum without claiming unverified dependency compatibility. - This PR supersedes the incomplete dependency/README-only approach in [PR #214](https://github.com/DCC-EX/EX-Installer/pull/214). PR #214 remains open and is not being closed or modified by this PR.  ## Verified local results  - PASS - bundled Python unittest discover -s tests -v: 4 tests passed. - PASS - no-write AST/compile audit: all 28 tracked Python files compiled successfully. - PASS - git diff --check. - PASS - introduced-line length check against the repository's 120-character configuration. - PASS - bundled Python 3.12.13 pip check: no broken requirements found. - PASS - python -m ex_installer --help launcher smoke test exited 0. - PASS - final diff contains exactly README.md, ex_installer/__main__.py, ex_installer/preflight.py, and tests/test_preflight.py; worktree is clean. - NOTICE - the no-write compile audit reports two pre-existing invalid-escape warnings in ex_installer/ex_commandstation.py and ex_installer/file_manager.py; neither file is changed here.  ## Validation limits  - PASS - bundled Python 3.12.13 `compileall` with `PYTHONPYCACHEPREFIX` redirected to a writable temporary cache compiled `ex_installer` and `tests` successfully; the checkout remained clean. - N/A - flake8 and ruff are not installed in the bundled runtime. - N/A - repository-root unittest discover found no tests; the repository's available suite is under tests and passes with the explicit command above. - N/A - no current fork Actions run exists for this exact head, so there is no hosted application check to report. Required checks could not be independently established because the branch-protection status endpoint returned 404. - NOT RUN - no hardware is available.  Maintainer bench criteria for hardware follow-up: in a clean supported-Python virtual environment, install requirements.txt, connect a supported DCC-EX/ESP32 device, launch EX-Installer, reach Compile and Load, and verify that startup/upload proceeds without a missing serial-module error; record OS, Python version, device/USB serial identity, and the resulting log.  The PR is ready for maintainer review and is not ready for merge.

## Current exact-head CI status

N/A — No BanjoR fork Actions run exists for exact head `6d83dc3151de282fccece101c242277f57db661e`; no hosted code-test result is claimed. Local validation above is the available evidence.
