### PR TITLE
Fix TrackManager startup command ordering

### DIFF
--- a/ex_installer/ex_commandstation.py
+++ b/ex_installer/ex_commandstation.py
@@ -872,10 +872,6 @@ class EXCommandStation(WindowLayout):
         if self.power_on_switch.get() == "on" or self.track_modes_enabled.get() == "on":
             config_list.append("AUTOSTART\n")
 
-        # Enable join on startup if enabled
-        if self.power_on_switch.get() == "on":
-            config_list.append("POWERON\n")
-
         # write out trackmanager config, including roster entries if DCx
         if self.track_modes_enabled.get() == "on":
             try:
@@ -904,6 +900,12 @@ class EXCommandStation(WindowLayout):
             else:
                 line = "SET_TRACK(B," + self.track_b_combo.get() + ")\n"
             config_list.append(line)
+
+        # Power on after TrackManager modes have been configured so both tracks
+        # are available when the command is executed.
+        if self.power_on_switch.get() == "on":
+            config_list.append("POWERON\n")
+
         # Single AUTOSTART if either option enabled
         if self.power_on_switch.get() == "on" or self.track_modes_enabled.get() == "on":
             config_list.append("DONE\n\n")

--- a/tests/test_ex_commandstation.py
+++ b/tests/test_ex_commandstation.py
@@ -1,0 +1,73 @@
+import unittest
+
+try:
+    from ex_installer.ex_commandstation import EXCommandStation
+except ModuleNotFoundError as error:
+    if error.name != "customtkinter":
+        raise
+    EXCommandStation = None
+
+
+class _Value:
+    def __init__(self, value):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+
+class _Log:
+    def debug(self, *args):
+        pass
+
+    def error(self, *args):
+        pass
+
+
+def generated_lines(power_on="off", track_modes="off", track_a="MAIN",
+                    track_b="MAIN", track_a_id="3", track_b_id="4"):
+    view = EXCommandStation.__new__(EXCommandStation)
+    view.power_on_switch = _Value(power_on)
+    view.track_modes_enabled = _Value(track_modes)
+    view.track_a_combo = _Value(track_a)
+    view.track_b_combo = _Value(track_b)
+    view.track_a_id = _Value(track_a_id)
+    view.track_b_id = _Value(track_b_id)
+    view.log = _Log()
+    valid, lines = view.generate_myAutomation()
+    assert valid
+    return lines
+
+
+@unittest.skipUnless(EXCommandStation is not None,
+                     "customtkinter is required for EXCommandStation tests")
+class GenerateMyAutomationTests(unittest.TestCase):
+    def test_combined_startup_orders_track_modes_before_power(self):
+        self.assertEqual(
+            generated_lines(power_on="on", track_modes="on"),
+            ["AUTOSTART\n", "SET_TRACK(A,MAIN)\n", "SET_TRACK(B,MAIN)\n",
+             "POWERON\n", "DONE\n\n"])
+
+    def test_power_only_output_is_unchanged(self):
+        self.assertEqual(
+            generated_lines(power_on="on"),
+            ["AUTOSTART\n", "POWERON\n", "DONE\n\n"])
+
+    def test_track_only_output_is_unchanged(self):
+        self.assertEqual(
+            generated_lines(track_modes="on"),
+            ["AUTOSTART\n", "SET_TRACK(A,MAIN)\n", "SET_TRACK(B,MAIN)\n",
+             "DONE\n\n"])
+
+    def test_dc_track_output_keeps_roster_entries_after_done(self):
+        self.assertEqual(
+            generated_lines(power_on="on", track_modes="on", track_a="DC",
+                            track_b="DC"),
+            ["AUTOSTART\n", "SETLOCO(3) SET_TRACK(A,DC)\n",
+             "SETLOCO(4) SET_TRACK(B,DC)\n", "POWERON\n", "DONE\n\n",
+             "ROSTER(3,\"DC TRACK A\",\"/* /\")\n",
+             "ROSTER(4,\"DC TRACK B\",\"/* /\")\n"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Automatic issue closing  Fixes #207  ## Issue and scope  - Authoritative issue: [EX-Installer #207](https://github.com/DCC-EX/EX-Installer/issues/207). - Scope: change `EXCommandStation.generate_myAutomation()` so generated startup output emits `AUTOSTART`, TrackManager `SET_TRACK`/DC `SETLOCO` commands, `POWERON`, then `DONE`; preserve existing roster output and unrelated configuration behavior. - Files changed: [`ex_installer/ex_commandstation.py`](https://github.com/DCC-EX/EX-Installer/blob/868ea3ce3358ab0f2c5f1e309975ea130b8ef958/ex_installer/ex_commandstation.py) and [`tests/test_ex_commandstation.py`](https://github.com/DCC-EX/EX-Installer/blob/868ea3ce3358ab0f2c5f1e309975ea130b8ef958/tests/test_ex_commandstation.py). - Personal integration code and unrelated protocol behavior are explicitly out of scope. - Superseded PRs: none identified; repository search found this as the only PR for issue #207.  ## Validation  - Full available pytest suite: `python -m pytest -q -p no:cacheprovider` — **4 passed**. - Full available unittest suite: `python -m unittest discover -s tests -v` — **4 passed**. - Focused regression suite: `python -m pytest -q -p no:cacheprovider tests/test_ex_commandstation.py` — **4 passed**. - Compile/static checks: `python -m compileall -q ex_installer tests` — **passed**; in-memory compilation of both changed files — **passed**. - Diff hygiene: `git diff --check` — **passed**; final checkout clean with exactly the two changed paths above. - Pre-existing warning: in-memory compilation reports the existing `ex_commandstation.py:727` invalid escape-sequence warning; this change does not touch that line.  ## Unavailable checks  - Repository-root `python -m unittest discover -v` is not a usable suite entry point: it discovered 0 tests and returned exit 5 because tests are under `tests/`; explicit discovery above passed. - PASS - bundled Python 3.12.13 `compileall -q -f ex_installer tests` with `PYTHONPYCACHEPREFIX` redirected to a writable temporary cache completed successfully; the checkout remained clean. - `flake8`, Black, isort, and Ruff are not installed, and no repository formatter workflow is configured. - GitHub Actions: the repository exposes Docs and project-automation workflows, not a Python test/CI workflow. [Docs run #35](https://github.com/DCC-EX/EX-Installer/actions/runs/31941248673) is `action_required` with no jobs; no required test check is available. - Hardware validation: **Not run—no hardware available**; it is not required for this source-level output-ordering change. If maintainers want a bench check, configure both tracks A and B as MAIN with auto power-on, generate `myAutomation.h`, and verify the command order is `AUTOSTART`, both `SET_TRACK` lines, `POWERON`, `DONE`.  This pull request is ready for maintainer review.

## Current exact-head CI status

N/A — No BanjoR fork Actions run exists for exact head `868ea3ce3358ab0f2c5f1e309975ea130b8ef958`; no hosted code-test result is claimed. Local validation above is the available evidence.
