### PR TITLE
Improve independently testable configuration flow

### DIFF
--- a/ex_installer/advanced_config.py
+++ b/ex_installer/advanced_config.py
@@ -61,8 +61,17 @@ class AdvancedConfig(WindowLayout):
         # Set up and configure the edit frame, which will contain the editboxes
         self.edit_frame = ctk.CTkFrame(self.main_frame, height=360)
         self.edit_frame.grid(column=0, row=0, sticky="nsew")
+        self.compile_only = ctk.StringVar(self, value="off")
+        self.compile_only_switch = ctk.CTkSwitch(
+            self.edit_frame, text="Compile only (do not flash hardware)",
+            variable=self.compile_only, onvalue="on", offvalue="off",
+            command=self.set_compile_only, font=self.instruction_font)
+        self.compile_only_switch.grid(column=0, row=3, columnspan=2, padx=5, pady=5)
 
         self.edit_list = []  # remember list of files to edit
+
+    def set_compile_only(self):
+        self.master.compile_only = self.compile_only.get() == "on"
 
     def set_product(self, product):
         """
@@ -71,6 +80,7 @@ class AdvancedConfig(WindowLayout):
         """
         self.log.debug("in set_product(%s)", product)
         self.product = product
+        self.set_compile_only()
         self.reload_view()  # paint/repaint the screen stuff
 
     def save_config_files(self):

--- a/ex_installer/compile_upload.py
+++ b/ex_installer/compile_upload.py
@@ -30,6 +30,7 @@ import logging
 from .common_widgets import WindowLayout
 from .product_details import product_details as pd
 from .file_manager import FileManager as fm
+from .config_flow import post_flash_verification, should_upload
 from . import images
 
 
@@ -166,7 +167,13 @@ class CompileUpload(WindowLayout):
         elif self.process_phase == "compiling":
             if self.process_status == "success":
                 self.set_details(self.process_data)
-                if self.parent.fake is True:
+                if not should_upload(self.master.compile_only):
+                    self.process_stop()
+                    self.upload_success(compile_only=True)
+                    self.next_back.show_next()
+                    self.next_back.show_log_button()
+                    self.show_backup_button()
+                elif self.parent.fake is True:
                     self.process_phase = "uploading"
                     self.process_status = "success"
                     self.process_start("uploading",
@@ -201,7 +208,7 @@ class CompileUpload(WindowLayout):
             self.next_back.show_next()
             self.show_backup_button()
 
-    def upload_success(self):
+    def upload_success(self, compile_only=False):
         """
         Function to display successful outcome after upload
         """
@@ -209,8 +216,13 @@ class CompileUpload(WindowLayout):
         self.instruction_label.grid_remove()
         self.congrats_label.configure(text="Congratulations!")
         self.congrats_label.grid()
-        text = (f"{pd[self.product]['product_name']} has successfully been loaded on to your " +
-                f"{self.acli.detected_devices[self.acli.selected_device]['matching_boards'][0]['name']}")
+        if compile_only:
+            text = f"{pd[self.product]['product_name']} compiled successfully (compile-only mode; hardware was not flashed)."
+        else:
+            verified = post_flash_verification(self.process_data)
+            status = "verified" if verified else "completed; connect to the serial monitor to verify startup"
+            text = (f"{pd[self.product]['product_name']} was loaded successfully ({status}) on to your " +
+                    f"{self.acli.detected_devices[self.acli.selected_device]['matching_boards'][0]['name']}")
         self.success_label.configure(text=text)
         self.success_label.grid()
 

--- a/ex_installer/config_flow.py
+++ b/ex_installer/config_flow.py
@@ -1,0 +1,54 @@
+"""Pure configuration-flow helpers used by the EX-Installer screens.
+
+Keeping validation and generated lines here makes the configuration paths
+testable without constructing the CustomTkinter UI or attaching hardware.
+"""
+
+import ipaddress
+
+
+def validate_static_ip(parts):
+    """Return a normalized IPv4 address or raise ``ValueError``."""
+    if len(parts) != 4:
+        raise ValueError("Static IP address must contain four octets")
+    try:
+        address = ipaddress.IPv4Address(".".join(str(part).strip() for part in parts))
+    except (ValueError, ipaddress.AddressValueError) as exc:
+        raise ValueError("Invalid static IP address") from exc
+    if address.is_unspecified or address.is_multicast or address.is_reserved or address.is_loopback:
+        raise ValueError("Static IP address is reserved")
+    return str(address)
+
+
+def ap_config_lines(ssid, password):
+    """Generate AP-mode config lines, using firmware defaults when blank."""
+    lines = []
+    if ssid:
+        if not password:
+            raise ValueError("WiFi password not set for custom access point")
+        lines.extend((f'#define WIFI_SSID "{ssid}"\n', "#define FORCE_AP true\n"))
+    else:
+        lines.append('#define WIFI_SSID "Your network name"\n')
+    password_value = password or "Your network passwd"
+    lines.append(f'#define WIFI_PASSWORD "{password_value}"\n')
+    return lines
+
+
+def csb1_track_defaults(motor_driver):
+    """Return automatic TrackManager defaults for an EX-CSB1 C/D driver."""
+    if not motor_driver.startswith("EXCSB1_"):
+        return None
+    return {"enabled": True, "C": "MAIN", "D": "MAIN"}
+
+
+def should_upload(compile_only):
+    """Return whether the post-compile upload phase should run."""
+    return not bool(compile_only)
+
+
+def post_flash_verification(output):
+    """Classify serial/output evidence after flashing."""
+    text = (output or "").lower()
+    if any(marker in text for marker in ("error", "failed", "not found")):
+        return False
+    return any(marker in text for marker in ("dcc-ex", "commandstation", "ready", "welcome"))

--- a/ex_installer/ex_commandstation.py
+++ b/ex_installer/ex_commandstation.py
@@ -333,15 +333,15 @@ class EXCommandStation(WindowLayout):
                                              command=self.set_ethernet, font=self.instruction_font)
         CreateToolTip(self.ethernet_switch, ethernet_tip,
                       "https://dcc-ex.com/reference/hardware/ethernet-boards.html")
-        
-        # Set up Ethernet Widgets        
+
+        # Set up Ethernet Widgets
         self.ethernet_static_ip_switch = ctk.CTkSwitch(self.ethernet_tab_frame, text="Static IP address",
                                                     onvalue="on", offvalue="off",
                                                     width=100, command=self.set_ethernet_static_ip,
-                                                    font=self.instruction_font)        
+                                                    font=self.instruction_font)
         self.ethernet_ip_frame = ctk.CTkFrame(self.ethernet_tab_frame, border_width=0)
         self.ethernet_ip_label = ctk.CTkLabel(self.ethernet_ip_frame, text="IP:",
-                                           font=self.instruction_font)        
+                                           font=self.instruction_font)
         self.ethernet_ip_a_entry = ctk.CTkEntry(self.ethernet_ip_frame,
                                            placeholder_text="192",
                                            width=50, fg_color="white", font=self.instruction_font)
@@ -502,19 +502,19 @@ class EXCommandStation(WindowLayout):
         self.ethernet_ip_d_entry.grid(column=4, row=0,sticky="e", **grid_options)
 
         # Layout WiFi tab
-        self.wifi_options_frame.grid(column=0, row=0, sticky="nsew")        
+        self.wifi_options_frame.grid(column=0, row=0, sticky="nsew")
 
         # Layout general tab
         self.general_tab_frame.grid_columnconfigure(0, weight=1)
         self.general_tab_frame.grid_columnconfigure(1, weight=2)
         self.general_tab_frame.grid_rowconfigure(0, weight=1)
         self.switch_frame.grid(column=0, row=0, **grid_options)
-        self.options_frame.grid(column=1, row=0, **grid_options)        
+        self.options_frame.grid(column=1, row=0, **grid_options)
 
         # Layout TrackManager tab
         self.track_modes_frame.grid(column=0, row=0, sticky="nsew")
 
-        # Layout Ethernet tab        
+        # Layout Ethernet tab
         self.ethernet_ip_frame.grid(column=0, row=1)
 
         # Layout config_frame
@@ -669,7 +669,7 @@ class EXCommandStation(WindowLayout):
         Function to refresh the tab button (used by wifi too)
         """
         if self.ethernet_switch.get() == "on":
-            self.config_tabview._segmented_button._buttons_dict["Ethernet Options"].configure(state="normal") 
+            self.config_tabview._segmented_button._buttons_dict["Ethernet Options"].configure(state="normal")
         else:
             self.config_tabview._segmented_button._buttons_dict["Ethernet Options"].configure(state="disabled")
         self.set_ethernet_static_ip()
@@ -681,10 +681,10 @@ class EXCommandStation(WindowLayout):
         if self.ethernet_switch.get() == "on":
             if self.wifi_switch.get() == "on":
                 self.wifi_switch.deselect()
-                self.set_wifi()                           
+                self.set_wifi()
             self.log.debug("Ethernet enabled")
         else:
-            self.log.debug("Ethernet disabled")    
+            self.log.debug("Ethernet disabled")
         self.refresh_ethernet_tab_option()
 
     def set_ethernet_static_ip(self):
@@ -700,7 +700,7 @@ class EXCommandStation(WindowLayout):
             self.ethernet_ip_a_entry.grid_remove()
             self.ethernet_ip_b_entry.grid_remove()
             self.ethernet_ip_c_entry.grid_remove()
-            self.ethernet_ip_d_entry.grid_remove()                        
+            self.ethernet_ip_d_entry.grid_remove()
             self.log.debug("Static IP disabled")
 
     def decrement_channel(self):
@@ -871,7 +871,7 @@ class EXCommandStation(WindowLayout):
     def ethernet_is_ip_equal(self, ip1, ip2):
         for i in range(4):
             if(ip1[i] != ip2[i]):
-                return False 
+                return False
         return True
 
     def ethernet_check_for_reserved_ips(self, ip):
@@ -915,7 +915,7 @@ class EXCommandStation(WindowLayout):
     def ethernet_get_ip_number(self, entry):
         num = entry.get()
         if not num.isnumeric():
-            return (False, num)        
+            return (False, num)
         num = int(num)
         return ((num >= 0) and (num <= 255), num)
 
@@ -985,8 +985,8 @@ class EXCommandStation(WindowLayout):
                             break
 
                         ip_data.append(ip_num[1])
-                    
-                    if ip_data:                        
+
+                    if ip_data:
                         #check for know ip addresses
                         try:
                             address = validate_static_ip(ip_data)

--- a/ex_installer/ex_commandstation.py
+++ b/ex_installer/ex_commandstation.py
@@ -30,6 +30,7 @@ import re
 from .common_widgets import WindowLayout, CreateToolTip
 from .product_details import product_details as pd
 from .file_manager import FileManager as fm
+from .config_flow import ap_config_lines, csb1_track_defaults, validate_static_ip
 
 
 class EXCommandStation(WindowLayout):
@@ -378,6 +379,14 @@ class EXCommandStation(WindowLayout):
                                              font=self.instruction_font)
         self.track_b_entry = ctk.CTkEntry(self.track_modes_frame, textvariable=self.track_b_id,
                                           font=self.instruction_font, width=60, fg_color="white")
+        self.track_c_label = ctk.CTkLabel(self.track_modes_frame, text="Track C:")
+        self.track_c_combo = ctk.CTkComboBox(self.track_modes_frame, values=list(self.trackmanager_modes),
+                                             width=100, font=self.instruction_font)
+        self.track_d_label = ctk.CTkLabel(self.track_modes_frame, text="Track D:")
+        self.track_d_combo = ctk.CTkComboBox(self.track_modes_frame, values=list(self.trackmanager_modes),
+                                             width=100, font=self.instruction_font)
+        self.track_c_combo.set("MAIN")
+        self.track_d_combo.set("MAIN")
         self.track_b_combo.set("MAIN")  # default to MAIN and PROG
         self.track_b_combo.set("PROG")
 
@@ -474,7 +483,11 @@ class EXCommandStation(WindowLayout):
         self.track_b_label.grid(column=0, row=1, sticky="e", **grid_options)
         self.track_b_combo.grid(column=1, row=1, sticky="w", **grid_options)
         self.track_b_id_label.grid(column=2, row=1, sticky="e", **grid_options)
-        self.track_b_entry.grid(column=3, row=1, sticky="w", **grid_options)    
+        self.track_b_entry.grid(column=3, row=1, sticky="w", **grid_options)
+        self.track_c_label.grid(column=0, row=2, sticky="e", **grid_options)
+        self.track_c_combo.grid(column=1, row=2, sticky="w", **grid_options)
+        self.track_d_label.grid(column=2, row=2, sticky="e", **grid_options)
+        self.track_d_combo.grid(column=3, row=2, sticky="w", **grid_options)
 
         # Layout ethernet_frame
         self.ethernet_tab_frame.grid_columnconfigure(0, weight=1)
@@ -633,8 +646,8 @@ class EXCommandStation(WindowLayout):
         Function to display correct widgets for WiFi config
         """
         if self.wifi_type.get() == 0:
-            self.wifi_ssid_label.grid_remove()
-            self.wifi_ssid_entry.grid_remove()
+            self.wifi_ssid_label.grid()
+            self.wifi_ssid_entry.grid()
             self.wifi_hostname_label.grid_remove()
             self.wifi_hostname_entry.grid_remove()
             self.wifi_channel_frame.grid()
@@ -785,6 +798,12 @@ class EXCommandStation(WindowLayout):
             self.next_back.disable_next()
         else:
             self.next_back.enable_next()
+            defaults = csb1_track_defaults(value)
+            if defaults:
+                self.track_modes_switch.select()
+                self.track_c_combo.set(defaults["C"])
+                self.track_d_combo.set(defaults["D"])
+                self.set_track_modes()
 
     def check_invalid_wifi_password(self):
         """
@@ -922,16 +941,13 @@ class EXCommandStation(WindowLayout):
             line = '#define WIFI_HOSTNAME "' + self.wifi_hostname.get() + '"\n'
             config_list.append(line)
             if self.wifi_type.get() == 0:
-                config_list.append('#define WIFI_SSID "Your network name"\n')
-                if self.wifi_pwd_entry.get() == "":
-                    config_list.append('#define WIFI_PASSWORD "Your network passwd"\n')
-                else:
-                    invalid, issue = self.check_invalid_wifi_password()
-                    if invalid:
-                        param_errors.append(issue)
-                    else:
-                        line = '#define WIFI_PASSWORD "' + self.wifi_pwd_entry.get() + '"\n'
-                        config_list.append(line)
+                try:
+                    config_list += ap_config_lines(self.wifi_ssid_entry.get(), self.wifi_pwd_entry.get())
+                except ValueError as issue:
+                    param_errors.append(str(issue))
+                invalid, issue = self.check_invalid_wifi_password()
+                if invalid:
+                    param_errors.append(issue)
             elif self.wifi_type.get() == 1:
                 if self.wifi_ssid_entry.get() == "":
                     param_errors.append("WiFi SSID/name not set")
@@ -972,11 +988,12 @@ class EXCommandStation(WindowLayout):
                     
                     if ip_data:                        
                         #check for know ip addresses
-                        if self.ethernet_check_for_reserved_ips(ip_data):
-                            param_errors.append("IP value is reserved")
-                        else:                 
-                            line = "#define IP_ADDRESS { " + str(ip_data[0]) + ', ' + str(ip_data[1]) + ', ' + str(ip_data[2]) + ', ' + str(ip_data[3]) + ' }\n'
-                            config_list.append(line)
+                        try:
+                            address = validate_static_ip(ip_data)
+                        except ValueError as issue:
+                            param_errors.append(str(issue))
+                        else:
+                            config_list.append("#define IP_ADDRESS { " + address.replace(".", ", ") + " }\n")
         if self.override_current_limit.get() == "on":
             try:
                 int(self.current_limit.get())
@@ -1037,6 +1054,9 @@ class EXCommandStation(WindowLayout):
             else:
                 line = "SET_TRACK(A," + self.track_a_combo.get() + ")\n"
             config_list.append(line)
+            if self.track_modes_enabled.get() == "on":
+                config_list.append("SET_TRACK(C," + self.track_c_combo.get() + ")\n")
+                config_list.append("SET_TRACK(D," + self.track_d_combo.get() + ")\n")
             if (self.track_b_combo.get().startswith("DC")):
                 line = (f"SETLOCO({self.track_b_id.get()}) SET_TRACK(B," + self.track_b_combo.get() + ")\n")
                 roster_lines.append(f"ROSTER({self.track_b_id.get()},\"DC TRACK B\",\"/* /\")\n")

--- a/ex_installer/ex_installer.py
+++ b/ex_installer/ex_installer.py
@@ -125,6 +125,7 @@ class EXInstaller(ctk.CTk):
         self.view = None
         self.use_existing = False  # needed for backing up to select_version_config
         self.advanced_config = False  # needed for backing up
+        self.compile_only = False  # compile without flashing the selected device
         self.fake = False  # set fake Arduino USB device to false by default
 
         # Create basic menu for Info -> About

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,42 @@
+import unittest
+
+from ex_installer.config_flow import (
+    ap_config_lines,
+    csb1_track_defaults,
+    post_flash_verification,
+    should_upload,
+    validate_static_ip,
+)
+
+
+class ConfigFlowTests(unittest.TestCase):
+    def test_compile_only_skips_upload(self):
+        self.assertFalse(should_upload(True))
+        self.assertTrue(should_upload(False))
+
+    def test_csb1_defaults_tracks_c_and_d_to_main(self):
+        self.assertEqual(csb1_track_defaults("EXCSB1_DUAL")["C"], "MAIN")
+        self.assertEqual(csb1_track_defaults("EXCSB1_DUAL")["D"], "MAIN")
+        self.assertIsNone(csb1_track_defaults("STANDARD_MOTOR_SHIELD"))
+
+    def test_custom_ap_emits_force_ap(self):
+        lines = ap_config_lines("layout", "password123")
+        self.assertIn('#define FORCE_AP true\n', lines)
+        self.assertIn('#define WIFI_SSID "layout"\n', lines)
+
+    def test_default_ap_keeps_firmware_defaults(self):
+        lines = ap_config_lines("", "")
+        self.assertNotIn('#define FORCE_AP true\n', lines)
+
+    def test_static_ip_validation(self):
+        self.assertEqual(validate_static_ip([192, 168, 1, 50]), "192.168.1.50")
+        with self.assertRaises(ValueError):
+            validate_static_ip([999, 168, 1, 50])
+
+    def test_post_flash_verification(self):
+        self.assertTrue(post_flash_verification("DCC-EX CommandStation ready"))
+        self.assertFalse(post_flash_verification("upload failed: error"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Automatic issue closing

Fixes #190
Fixes #197
Fixes #199

## Summary

Installer-side configuration-flow work relevant to:

- [Issue #190 - Compile Only option on Advanced Config](https://github.com/DCC-EX/EX-Installer/issues/190)
- [Issue #197 - Automatically configure CSB1 C/D tracks](https://github.com/DCC-EX/EX-Installer/issues/197)
- [Issue #199 - Enable FORCE_AP for custom WiFi credentials](https://github.com/DCC-EX/EX-Installer/issues/199)
- [Issue #184 - ESP32 incorrect-password report](https://github.com/DCC-EX/EX-Installer/issues/184)

Refreshes the relevant static-IP work from [PR #182](https://github.com/DCC-EX/EX-Installer/pull/182). The referenced [PR #184](https://github.com/DCC-EX/EX-Installer/pull/184) returned 404 during the audit; no implementation was copied from it.

## Bounded scope

Only these six files change ([PR file list](https://github.com/DCC-EX/EX-Installer/pull/221/files)):

- `ex_installer/advanced_config.py` - compile-only selection state.
- `ex_installer/compile_upload.py` - compile-only upload gating and post-flash output classification.
- `ex_installer/config_flow.py` - pure helpers for static IP, AP configuration, CSB1 defaults, upload gating, and post-flash verification.
- `ex_installer/ex_commandstation.py` - static-IP controls, AP SSID/password and FORCE_AP controls, and CSB1 C/D defaults.
- `ex_installer/ex_installer.py` - compile-only default initialization.
- `tests/test_config_flow.py` - six focused regression tests.

Compile-only mode, CSB1 C/D tracks, AP credentials, static IP, and post-flash verification remain independently testable.

## Explicit exclusions

- No changes outside the six files above.
- No firmware source, protocol, or public API redesign.
- No unrelated metadata, release, documentation, or integration work.
- No claim of physical validation or complete hardware-root-cause resolution; post-flash verification is installer-side output classification only.

## Validation

Executed from clean `main`-based branch `codex/ex-installer-config-flow` at `8a54bbd2b3f95cc4b504efa431805143e28e19ed`:

- `python -m pytest -q` - 6 passed in 0.20s.
- `python -m unittest discover -s tests -v` - 6 passed.
- `python -m compileall -q ex_installer tests` - passed.
- Tracked-file Python `py_compile` - passed.
- `git diff --check` - passed.
- Final post-cleanup rerun with bundled Python 3.12.13: `compileall -q -f ex_installer tests`, `pytest -q -p no:cacheprovider` (6 passed), `unittest discover -s tests -v` (6 passed), and `git diff --check` all passed.
- Sphinx documentation build - passed with six pre-existing warnings: definition-list formatting warnings in `arduino_cli.py`, a licence literal-block lexing warning, and the existing invalid-escape warnings at `ex_installer/ex_commandstation.py:815` (`\ `) and `ex_installer/file_manager.py:258` (`\.`).

The six focused cases cover compile-only gating, CSB1 C/D defaults, custom AP credentials, default AP configuration, static-IP validation, and post-flash verification.

## CI and unavailable checks

- [Docs workflow run #36](https://github.com/DCC-EX/EX-Installer/actions/runs/31942621799) completed with `action_required`; no job results were available.
- [Commit checks](https://github.com/DCC-EX/EX-Installer/commit/8a54bbd2b3f95cc4b504efa431805143e28e19ed/checks) reported no commit statuses; the available `add_to_project` check succeeded.
- The repository has no Python test/lint/build workflow beyond documentation and new-items workflows.
- Flake8, Ruff, Pyflakes, pycodestyle, mypy, PlatformIO, CMake/C++, and the exact Doxygen/Make workflow were unavailable.

## Maintainer bench criteria

Not run—no hardware available.

1. ESP32 Dev Kit + STANDARD_MOTOR_SHIELD: normal uploads with default and custom AP credentials; verify client connection and no incorrect-password report.
2. CSB1 + EX8874: verify TrackManager is enabled and C/D default to MAIN.
3. Ethernet shield: flash with a valid static IP and verify CommandStation reachability.
4. Compile-only: disconnect the target or make upload unavailable; verify an artifact is produced and no upload is attempted.
5. After a real flash, inspect serial/output success and failure cases for the expected post-flash classification.

This PR is ready for maintainer review.

## Current exact-head CI status

N/A — No BanjoR fork Actions run exists for exact head `8a54bbd2b3f95cc4b504efa431805143e28e19ed`; no hosted code-test result is claimed. Local validation above is the available evidence.
