### PR TITLE
Fix empty directory detection

### DIFF
--- a/ex_installer/file_manager.py
+++ b/ex_installer/file_manager.py
@@ -332,10 +332,7 @@ class FileManager:
 
         Returns True if so, False if not
         """
-        if os.listdir(dir) > 0:
-            return False
-        else:
-            return True
+        return not os.listdir(dir)
 
     @staticmethod
     def copy_config_files(source_dir, dest_dir, file_list):

--- a/tests/test_file_manager.py
+++ b/tests/test_file_manager.py
@@ -1,0 +1,19 @@
+import os
+
+from ex_installer.file_manager import FileManager
+
+
+def test_dir_is_empty_returns_true_for_empty_directory(tmp_path):
+    directory = os.path.join(str(tmp_path), "empty")
+    os.mkdir(directory)
+
+    assert FileManager.dir_is_empty(directory) is True
+
+
+def test_dir_is_empty_returns_false_for_non_empty_directory(tmp_path):
+    directory = os.path.join(str(tmp_path), "non-empty")
+    os.mkdir(directory)
+    with open(os.path.join(directory, "file.txt"), "w", encoding="utf-8") as file:
+        file.write("content")
+
+    assert FileManager.dir_is_empty(directory) is False


### PR DESCRIPTION
## Automatic issue closing  Fixes #205 Fixes #215  ## Summary  - Fix `FileManager.dir_is_empty` so it returns whether a directory contains no entries. - Add isolated regression tests for empty and non-empty directories using platform-neutral path construction.  ## Root cause and impact  `os.listdir` returns a list, but the previous implementation compared that list directly with an integer, raising `TypeError` instead of returning a boolean. This affected the installer path that checks for an empty local product directory.  ## Bounded scope and exclusions  This PR is limited to:  - `ex_installer/file_manager.py::FileManager.dir_is_empty` - `tests/test_file_manager.py`  It does not change installer APIs, protocols, configuration behavior, dependencies, documentation, build artifacts, or unrelated product/traction/hardware code.  ## Authoritative references  - [Issue #205 — uncaught exception when checking an empty product list](https://github.com/DCC-EX/EX-Installer/issues/205) - [Issue #215 — EX-Installer support report with the same traceback](https://github.com/DCC-EX/EX-Installer/issues/215)  No superseded or duplicate PR was found in repository searches for the affected function, file, or empty-directory bug.  ## Validation  Local checks:  - Focused pytest: `C:\Users\banjo\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -m pytest -p no:cacheprovider --basetemp <temporary-directory> tests/test_file_manager.py -q` — **2 passed** - Full available pytest suite: same bundled Python with `-p no:cacheprovider` — **2 passed** - No-write syntax audit using Python `compile()` across 27 repository Python files — **passed** - `git diff --check origin/main...HEAD` — **passed**  Unavailable checks:  - PASS - bundled Python 3.12.13 `compileall -q -f ex_installer tests` with `PYTHONPYCACHEPREFIX` redirected to a writable temporary cache completed successfully; the checkout remained clean. - `flake8`, `black`, and `ruff` are not installed in the bundled runtime. - [GitHub Actions run](https://github.com/DCC-EX/EX-Installer/actions/runs/31942676102) is `action_required` with no jobs, and no commit status checks were reported. CI is therefore not claimed as green. See the [PR checks](https://github.com/DCC-EX/EX-Installer/pull/222/checks).  Hardware: Not run—no hardware available. Hardware is not required for this filesystem-only change; maintainers can reproduce the relevant behavior by running the two pytest cases on the supported operating systems and confirming empty and non-empty temporary directories return `True` and `False`, respectively.

## Current exact-head CI status

N/A — No BanjoR fork Actions run exists for exact head `7ac3a2531910181cad210f57b9678d1a5fcdbdb2`; no hosted code-test result is claimed. Local validation above is the available evidence.
