### PR TITLE
Make Arduino CLI dependency installation idempotent

### DIFF
--- a/ex_installer/manage_arduino_cli.py
+++ b/ex_installer/manage_arduino_cli.py
@@ -30,6 +30,33 @@ from .common_widgets import WindowLayout, CreateToolTip
 from . import images
 
 
+def _items_from_cli_response(data, collection_key):
+    """Return the installed-item list from Arduino CLI jsonmini output."""
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        items = data.get(collection_key, [])
+        return items if isinstance(items, list) else None
+    return None
+
+
+def _installed_version(item, kind):
+    """Extract an installed id/name and version from a CLI inventory item."""
+    if not isinstance(item, dict):
+        return None, None
+    if kind == "platform":
+        return item.get("id"), item.get("installed", item.get("installed_version"))
+    details = item.get("library")
+    if not isinstance(details, dict):
+        return None, None
+    return details.get("name"), details.get("version")
+
+
+def _is_dependency_installed(items, identifier, version, kind):
+    """Define the idempotence boundary: exact identity and exact version."""
+    return any(_installed_version(item, kind) == (identifier, version) for item in items)
+
+
 class ManageArduinoCLI(WindowLayout):
     # Define text to use in labels
     intro_text = ("We use the Arduino Command Line Interface (CLI) to upload the DCC-EX products to your Arduino. " +
@@ -132,6 +159,8 @@ class ManageArduinoCLI(WindowLayout):
 
         # Flag to ensure the CLI is refreshed if necessary
         self.cli_needs_refresh = False
+        self.pending_package = None
+        self.pending_library = None
 
         # Set title and logo
         self.set_title_logo(images.EX_INSTALLER_LOGO)
@@ -342,10 +371,8 @@ class ManageArduinoCLI(WindowLayout):
         elif self.process_status == "success":
             # Arduino CLI 1.0.x moves output from a list of platforms to a key/value pair
             # If this is the case, set process_data to the value not the key/value pair
-            if len(self.process_data) > 0 and "platforms" in self.process_data:
-                if isinstance(self.process_data["platforms"], list):
-                    self.process_data = self.process_data["platforms"]
-            if isinstance(self.process_data, list):
+            platforms = _items_from_cli_response(self.process_data, "platforms")
+            if platforms is not None:
                 # Iterate through the list of platform packages that should be installed
                 for platform_name, platform_package in self.packages_to_install.items():
                     platform_id = platform_package["platform_id"]
@@ -356,16 +383,13 @@ class ManageArduinoCLI(WindowLayout):
                         selection = "on"
                     force_install = False
                     # Iterate through the installed platform packages to check the state
-                    for installed_platform in self.process_data:
-                        installed_platform_id = installed_platform["id"]
+                    for installed_platform in platforms:
+                        installed_platform_id, installed_version = _installed_version(
+                            installed_platform, "platform"
+                        )
                         # Output changed in CLI 1.0.1 so must check both installed and installed_version
-                        if "installed" in installed_platform:
-                            installed_version = installed_platform["installed"]
-                        elif "installed_version" in installed_platform:
-                            installed_version = installed_platform["installed_version"]
-                        else:
+                        if installed_version is None:
                             self.log.error(f"Arduino CLI output unknown:\n{installed_platform}")
-                            installed_version = None
                         # Only if the ID and installed versions match do we mark them as installed
                         if installed_platform_id == platform_id and installed_version == version:
                             state = "installed"
@@ -417,24 +441,14 @@ class ManageArduinoCLI(WindowLayout):
         elif self.process_status == "success":
             # Arduino CLI 1.0.x moves output from a list of platforms to a key/value pair
             # If this is the case, set process_data to the value not the key/value pair
-            if len(self.process_data) > 0 and "installed_libraries" in self.process_data:
-                if isinstance(self.process_data["installed_libraries"], list):
-                    self.process_data = self.process_data["installed_libraries"]
-            if isinstance(self.process_data, list):
+            libraries = _items_from_cli_response(self.process_data, "installed_libraries")
+            if libraries is not None:
                 # Iterate through the list of platform packages that should be installed
                 for library, library_details in self.libraries_to_install.items():
                     version = library_details["version"]
                     state = "not_installed"
-                    for installed_library in self.process_data:
-                        # Not all libs report name/version correctly, so validate first
-                        library_name = ""
-                        if "name" in installed_library["library"]:
-                            library_name = installed_library["library"]["name"]
-                        library_version = ""
-                        if "version" in installed_library["library"]:
-                            library_version = installed_library["library"]["version"]
-                        if library_name == library and library_version == version:
-                            state = "installed"
+                    if _is_dependency_installed(libraries, library, version, "library"):
+                        state = "installed"
                     self.libraries_to_install[library]["state"] = state
             self.process_stop()
             self.next_back.enable_next()
@@ -630,6 +644,9 @@ class ManageArduinoCLI(WindowLayout):
         Any other status is an error.
         """
         self.log.debug(f"_install_packages() {self.process_status}")
+        if self.process_status == "success" and self.pending_package:
+            self.packages_to_install[self.pending_package]["state"] = "installed"
+            self.pending_package = None
         # Get the number of packages still to be installed
         install_count = self._get_package_install_count()
         # We only actually need to start if we have any to install, or if the previous was successful with more to go
@@ -658,7 +675,7 @@ class ManageArduinoCLI(WindowLayout):
         We flag the package as installed here to prevent an endless loop, but this should be improved in future.
         """
         package = platform_id + "@" + version
-        self.packages_to_install[package_name]["state"] = "installed"
+        self.pending_package = package_name
         self.log.debug(f"_install_single_package() {self.process_status}\npackage_name: {package}, package: {package}")
         self.process_start("install_packages", f"Installing package {package_name}", "Manage_CLI")
         self.acli.install_package(self.acli.cli_file_path(), package, self.queue)
@@ -687,6 +704,9 @@ class ManageArduinoCLI(WindowLayout):
         Any other status is an error.
         """
         self.log.debug(f"_install_libraries() {self.process_status}")
+        if self.process_status == "success" and self.pending_library:
+            self.libraries_to_install[self.pending_library]["state"] = "installed"
+            self.pending_library = None
         # Get the number of libraries still to be installed
         install_count = self._get_library_install_count()
         # Only start if we have any to install, or if previous was successful and more to go
@@ -714,7 +734,7 @@ class ManageArduinoCLI(WindowLayout):
         Flag the library as installed here but that should be validated in a later version.
         """
         library = library_name + "@" + version
-        self.libraries_to_install[library_name]["state"] = "installed"
+        self.pending_library = library_name
         self.log.debug(f"_install_single_library() {self.process_status}\nlibrary: {library}, version: {version}")
         self.process_start("install_libraries", "Install Arduino library " + library, "Manage_CLI")
         self.acli.install_library(self.acli.cli_file_path(), library, self.queue)

--- a/tests/test_arduino_cli_idempotence.py
+++ b/tests/test_arduino_cli_idempotence.py
@@ -1,0 +1,35 @@
+import unittest
+
+from ex_installer.manage_arduino_cli import (
+    _installed_version,
+    _is_dependency_installed,
+    _items_from_cli_response,
+)
+
+
+class ArduinoCliInventoryTests(unittest.TestCase):
+    def test_accepts_bare_and_wrapped_platform_inventories(self):
+        platform = {"id": "arduino:avr", "installed_version": "1.8.6"}
+        self.assertEqual(_items_from_cli_response([platform], "platforms"), [platform])
+        self.assertEqual(_items_from_cli_response({"platforms": [platform]}, "platforms"), [platform])
+
+    def test_missing_or_malformed_inventory_is_not_an_install_success(self):
+        self.assertEqual(_items_from_cli_response({"platforms": None}, "platforms"), None)
+        self.assertEqual(_items_from_cli_response({"unexpected": []}, "platforms"), [])
+        self.assertFalse(_is_dependency_installed([], "arduino:avr", "1.8.6", "platform"))
+
+    def test_platform_requires_exact_id_and_version(self):
+        items = [{"id": "arduino:avr", "installed": "1.8.6"}]
+        self.assertTrue(_is_dependency_installed(items, "arduino:avr", "1.8.6", "platform"))
+        self.assertFalse(_is_dependency_installed(items, "arduino:avr", "1.8.5", "platform"))
+        self.assertEqual(_installed_version(items[0], "platform"), ("arduino:avr", "1.8.6"))
+
+    def test_library_requires_nested_name_and_exact_version(self):
+        items = [{"library": {"name": "Ethernet", "version": "2.0.2"}}]
+        self.assertTrue(_is_dependency_installed(items, "Ethernet", "2.0.2", "library"))
+        self.assertFalse(_is_dependency_installed(items, "Ethernet", "2.0.1", "library"))
+        self.assertFalse(_is_dependency_installed([{}], "Ethernet", "2.0.2", "library"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Automatic issue closing  Fixes #210 Fixes #211  ## Summary  Make Arduino CLI dependency discovery and installation converge at the manager boundary.  In scope: - Normalize supported Arduino CLI `jsonmini` core and library inventory shapes. - Treat an exact dependency identity plus exact version as installed. - Keep core/library installs pending until the CLI command succeeds, so failures remain retryable. - Add mock/fixture-style regression coverage for discovery and version matching.  Explicit exclusions: - No Arduino CLI network calls, hardware access, or upload/compile execution. - No GUI redesign, product/protocol changes, firmware changes, or dependency-version changes. - Personal integration code and unrelated protocol behavior are explicitly out of scope.  Authoritative issues: - [Issue #210: Cannot upgrade platform arduino:avr@1.8.3](https://github.com/DCC-EX/EX-Installer/issues/210) - [Issue #211: EX-Installer is in a loop managing the Arduino CLI](https://github.com/DCC-EX/EX-Installer/issues/211)  Superseded PRs: - None identified. This PR uses the corrected upstream-based branch; the earlier archive-only ancestry was repaired before publication.  ## Validation  - Focused and repository-scoped test suite: `python -m unittest discover -s tests -v` — 4 passed. - Focused regression file: [tests/test_arduino_cli_idempotence.py](https://github.com/BanjoR/EX-Installer/blob/ec34bfd9ff1a70169b8e17202d9396b5f20372b3/tests/test_arduino_cli_idempotence.py). - No-write AST syntax validation for both changed Python files — passed. - `git diff --check` — passed. - GitHub Actions [add_to_project check](https://github.com/DCC-EX/EX-Installer/actions/runs/31948038496/job/95167071806) — passed.
- N/A - Fork-hosted CI: the BanjoR/EX-Installer fork has no code-test workflow result for exact head ec34bfd9ff1a70169b8e17202d9396b5f20372b3; the add_to_project run above is project automation, not build or test validation.  Unavailable or incomplete checks: - Default `python -m unittest discover -v` was not usable because repository-wide discovery hung; the repository-scoped `tests` discovery above completed successfully. - PASS - bundled Python 3.12.13 `compileall -q -f ex_installer tests` with `PYTHONPYCACHEPREFIX` redirected to a writable temporary cache completed successfully; the checkout remained clean. - No repository code-test workflow or required-check policy was available to verify; the branch-protection API returned 404. - Hardware validation: Not run—no hardware available. Maintainers should exercise a clean temporary EX-Installer home with a mocked Arduino CLI that returns (1) bare and wrapped core/library inventories, (2) exact and mismatched versions, and (3) install success/failure responses; verify successful dependencies are not reinstalled and failures remain retryable without network or board access.  Scope review: only `ex_installer/manage_arduino_cli.py` and `tests/test_arduino_cli_idempotence.py` differ from `DCC-EX/EX-Installer:main`.

## Current exact-head CI status

N/A — No BanjoR fork Actions run exists for exact head `ec34bfd9ff1a70169b8e17202d9396b5f20372b3`; no hosted code-test result is claimed. Local validation above is the available evidence.
